### PR TITLE
Generic `concatenate` and `flatten`

### DIFF
--- a/README.org
+++ b/README.org
@@ -308,6 +308,7 @@ as any element fails the test.
 
 #+RESULTS:
 : (2 4 6 8)
+
 *** uncons, concatenate, flatten
 
 Split up a transduction of cons cells.

--- a/transducers/utils.lisp
+++ b/transducers/utils.lisp
@@ -43,7 +43,7 @@
 
 (defun preserving-reduced (reducer)
   "A helper function that wraps a reduced value twice since reducing
-functions (like list-reduce) unwraps them. tconcatenate is a good example: it
+functions (like list-reduce) unwraps them. `concatenate' is a good example: it
 re-uses its reducer on its input using list-reduce. If that reduction finishes
 early and returns a reduced value, list-reduce would 'unreduce' that value and
 try to continue the transducing process."


### PR DESCRIPTION
This PR enables `concatenate` and `flatten` to accept streams of things that aren't just lists. For now I've expanded this to include vectors, which implicitly supports strings as well.

```lisp
(transduce #'concatenate
           #'cons (list (cl:vector 1 2 3) (cl:list 4 5 6) (cl:vector 7 8 9)))
```
yields
```
(1 2 3 4 5 6 7 8 9)
```